### PR TITLE
Allow setting a single word

### DIFF
--- a/AnyBar/AppDelegate.m
+++ b/AnyBar/AppDelegate.m
@@ -225,7 +225,7 @@
         NSArray *stringArray = [msg componentsSeparatedByString:@" "];
         if ([self setImage:stringArray[0]])
             stringArray = [stringArray subarrayWithRange:NSMakeRange(1, stringArray.count - 1)];
-        if (stringArray.count > 1)
+        if (stringArray.count > 0)
         {
             [self setText:[stringArray componentsJoinedByString:@" "]];
         }


### PR DESCRIPTION
It was checking that the array had more than one item, so you could set the text to multiple words, but never a single word.
